### PR TITLE
Desabilitar SteamHEX Whitelist

### DIFF
--- a/resources/[vrp]/vrp/queue.lua
+++ b/resources/[vrp]/vrp/queue.lua
@@ -410,7 +410,7 @@ Citizen.CreateThread(function()
 
 
         -- Steam Whitelist
-        local steamNotWhitelisted = false
+        local steamNotWhitelisted = true
         local wlList = {}
         for line in io.lines("whitelist.txt") do
             table.insert(wlList, tostring(line))


### PR DESCRIPTION
manter desabilitada por padrão pra evitar dúvidas desnecessárias no discord